### PR TITLE
feat: add responsive design for mobile/desktop viewing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A demo application for viewing Gaussian Splats 3D data using [GaussianSplats3D](
 - [x] Implement loading state and progress indicator
 
 ### Low Priority
-- [ ] Add responsive design for mobile/desktop viewing
+- [x] Add responsive design for mobile/desktop viewing
 - [ ] Optimize performance for smooth rendering
 - [ ] Add export/screenshot functionality
 

--- a/app/components/CameraControls.tsx
+++ b/app/components/CameraControls.tsx
@@ -28,36 +28,36 @@ export default function CameraControls({
   };
 
   return (
-    <div className={`absolute top-4 right-4 ${className}`}>
-      <div className="bg-gray-900/90 backdrop-blur-sm rounded-lg shadow-xl border border-gray-700 p-2">
+    <div className={`absolute top-2 sm:top-4 right-2 sm:right-4 ${className}`}>
+      <div className="bg-gray-900/90 backdrop-blur-sm rounded-lg shadow-xl border border-gray-700 p-1 sm:p-2">
         {/* Camera Controls Toggle */}
         <button
           onClick={() => setIsExpanded(!isExpanded)}
-          className="flex items-center gap-2 px-3 py-2 text-gray-300 hover:text-white transition-colors"
+          className="flex items-center gap-1 sm:gap-2 px-2 sm:px-3 py-1 sm:py-2 text-gray-300 hover:text-white transition-colors"
           title="Camera Controls"
         >
-          <Camera className="w-5 h-5" />
-          <span className="text-sm font-medium">Camera</span>
-          <RotateCw className={`w-4 h-4 transition-transform ${isExpanded ? 'rotate-180' : ''}`} />
+          <Camera className="w-4 sm:w-5 h-4 sm:h-5" />
+          <span className="text-xs sm:text-sm font-medium hidden sm:inline">Camera</span>
+          <RotateCw className={`w-3 sm:w-4 h-3 sm:h-4 transition-transform ${isExpanded ? 'rotate-180' : ''}`} />
         </button>
 
         {/* Expanded Controls */}
         {isExpanded && (
-          <div className="mt-2 pt-2 border-t border-gray-700 space-y-2">
+          <div className="mt-1 sm:mt-2 pt-1 sm:pt-2 border-t border-gray-700 space-y-1 sm:space-y-2">
             {/* Mode Toggle */}
-            <div className="flex items-center gap-2 px-3 py-1">
+            <div className="flex items-center gap-1 sm:gap-2 px-2 sm:px-3 py-0.5 sm:py-1">
               <button
                 onClick={handleModeToggle}
-                className="flex items-center gap-2 px-3 py-2 bg-gray-800 hover:bg-gray-700 rounded-md text-sm text-gray-300 hover:text-white transition-all w-full"
+                className="flex items-center gap-1 sm:gap-2 px-2 sm:px-3 py-1 sm:py-2 bg-gray-800 hover:bg-gray-700 rounded-md text-xs sm:text-sm text-gray-300 hover:text-white transition-all w-full"
               >
                 {currentMode === 'orbit' ? (
                   <>
-                    <Eye className="w-4 h-4" />
+                    <Eye className="w-3 sm:w-4 h-3 sm:h-4" />
                     <span>Orbit Mode</span>
                   </>
                 ) : (
                   <>
-                    <Move className="w-4 h-4" />
+                    <Move className="w-3 sm:w-4 h-3 sm:h-4" />
                     <span>Pan Mode</span>
                   </>
                 )}
@@ -65,30 +65,30 @@ export default function CameraControls({
             </div>
 
             {/* Zoom Controls */}
-            <div className="flex items-center gap-2 px-3">
+            <div className="flex items-center gap-1 sm:gap-2 px-2 sm:px-3">
               <button
                 onClick={onZoomIn}
-                className="flex-1 flex items-center justify-center gap-1 px-2 py-2 bg-gray-800 hover:bg-gray-700 rounded-md text-sm text-gray-300 hover:text-white transition-all"
+                className="flex-1 flex items-center justify-center gap-0.5 sm:gap-1 px-1 sm:px-2 py-1 sm:py-2 bg-gray-800 hover:bg-gray-700 rounded-md text-xs sm:text-sm text-gray-300 hover:text-white transition-all"
                 title="Zoom In"
               >
-                <ZoomIn className="w-4 h-4" />
+                <ZoomIn className="w-3 sm:w-4 h-3 sm:h-4" />
               </button>
               <button
                 onClick={onZoomOut}
-                className="flex-1 flex items-center justify-center gap-1 px-2 py-2 bg-gray-800 hover:bg-gray-700 rounded-md text-sm text-gray-300 hover:text-white transition-all"
+                className="flex-1 flex items-center justify-center gap-0.5 sm:gap-1 px-1 sm:px-2 py-1 sm:py-2 bg-gray-800 hover:bg-gray-700 rounded-md text-xs sm:text-sm text-gray-300 hover:text-white transition-all"
                 title="Zoom Out"
               >
-                <ZoomOut className="w-4 h-4" />
+                <ZoomOut className="w-3 sm:w-4 h-3 sm:h-4" />
               </button>
             </div>
 
             {/* Reset View */}
-            <div className="px-3">
+            <div className="px-2 sm:px-3">
               <button
                 onClick={onReset}
-                className="w-full flex items-center justify-center gap-2 px-3 py-2 bg-blue-600 hover:bg-blue-700 rounded-md text-sm text-white transition-all"
+                className="w-full flex items-center justify-center gap-1 sm:gap-2 px-2 sm:px-3 py-1 sm:py-2 bg-blue-600 hover:bg-blue-700 rounded-md text-xs sm:text-sm text-white transition-all"
               >
-                <Maximize2 className="w-4 h-4" />
+                <Maximize2 className="w-3 sm:w-4 h-3 sm:h-4" />
                 <span>Reset View</span>
               </button>
             </div>
@@ -96,24 +96,24 @@ export default function CameraControls({
         )}
       </div>
 
-      {/* Control Instructions */}
-      <div className="mt-4 bg-gray-900/90 backdrop-blur-sm rounded-lg shadow-xl border border-gray-700 p-4 max-w-xs">
-        <h3 className="text-sm font-semibold text-gray-300 mb-2">Controls</h3>
-        <div className="space-y-1 text-xs text-gray-400">
-          <div className="flex items-center gap-2">
-            <span className="font-mono bg-gray-800 px-2 py-1 rounded">Left Click</span>
+      {/* Control Instructions - Hidden on mobile */}
+      <div className="hidden sm:block mt-2 sm:mt-4 bg-gray-900/90 backdrop-blur-sm rounded-lg shadow-xl border border-gray-700 p-2 sm:p-4 max-w-xs">
+        <h3 className="text-xs sm:text-sm font-semibold text-gray-300 mb-1 sm:mb-2">Controls</h3>
+        <div className="space-y-0.5 sm:space-y-1 text-xs text-gray-400">
+          <div className="flex items-center gap-1 sm:gap-2">
+            <span className="font-mono bg-gray-800 px-1 sm:px-2 py-0.5 sm:py-1 rounded text-xs">Left Click</span>
             <span>{currentMode === 'orbit' ? 'Rotate' : 'Pan'}</span>
           </div>
-          <div className="flex items-center gap-2">
-            <span className="font-mono bg-gray-800 px-2 py-1 rounded">Right Click</span>
+          <div className="flex items-center gap-1 sm:gap-2">
+            <span className="font-mono bg-gray-800 px-1 sm:px-2 py-0.5 sm:py-1 rounded text-xs">Right Click</span>
             <span>{currentMode === 'orbit' ? 'Pan' : 'Rotate'}</span>
           </div>
-          <div className="flex items-center gap-2">
-            <span className="font-mono bg-gray-800 px-2 py-1 rounded">Scroll</span>
+          <div className="flex items-center gap-1 sm:gap-2">
+            <span className="font-mono bg-gray-800 px-1 sm:px-2 py-0.5 sm:py-1 rounded text-xs">Scroll</span>
             <span>Zoom In/Out</span>
           </div>
-          <div className="flex items-center gap-2">
-            <span className="font-mono bg-gray-800 px-2 py-1 rounded">Middle Click</span>
+          <div className="flex items-center gap-1 sm:gap-2">
+            <span className="font-mono bg-gray-800 px-1 sm:px-2 py-0.5 sm:py-1 rounded text-xs">Middle Click</span>
             <span>Pan (Always)</span>
           </div>
         </div>

--- a/app/components/GaussianSplatViewer.tsx
+++ b/app/components/GaussianSplatViewer.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState, useCallback } from 'react';
 import { Viewer } from '@mkkellogg/gaussian-splats-3d';
 import CameraControls from './CameraControls';
 import ViewerSettings from './ViewerSettings';
+import MobileControls from './MobileControls';
 
 interface GaussianSplatViewerProps {
   modelUrl: string;
@@ -287,23 +288,28 @@ export default function GaussianSplatViewer({ modelUrl, className = '', showCont
         />
       )}
       
+      {/* Mobile Controls Info */}
+      {showControls && isInitialized && !loading && !error && (
+        <MobileControls />
+      )}
+      
       {loading && (
         <div className="absolute inset-0 flex items-center justify-center bg-black/50 pointer-events-none">
           <div className="text-center">
-            <div className="mb-4">
-              <div className="w-16 h-16 border-4 border-blue-500 border-t-transparent rounded-full animate-spin mx-auto" />
+            <div className="mb-2 sm:mb-4">
+              <div className="w-12 sm:w-16 h-12 sm:h-16 border-4 border-blue-500 border-t-transparent rounded-full animate-spin mx-auto" />
             </div>
-            <p className="text-white text-lg">Loading 3D Model...</p>
-            <p className="text-white text-sm mt-2">{progress}%</p>
+            <p className="text-white text-sm sm:text-lg">Loading 3D Model...</p>
+            <p className="text-white text-xs sm:text-sm mt-1 sm:mt-2">{progress}%</p>
           </div>
         </div>
       )}
 
       {error && (
-        <div className="absolute inset-0 flex items-center justify-center bg-black/75">
-          <div className="bg-red-500/20 border border-red-500 rounded-lg p-6 max-w-md">
-            <h3 className="text-red-500 text-lg font-semibold mb-2">Error Loading Model</h3>
-            <p className="text-red-300 text-sm">{error}</p>
+        <div className="absolute inset-0 flex items-center justify-center bg-black/75 p-4">
+          <div className="bg-red-500/20 border border-red-500 rounded-lg p-4 sm:p-6 max-w-md w-full">
+            <h3 className="text-red-500 text-base sm:text-lg font-semibold mb-1 sm:mb-2">Error Loading Model</h3>
+            <p className="text-red-300 text-xs sm:text-sm">{error}</p>
           </div>
         </div>
       )}

--- a/app/components/MobileControls.tsx
+++ b/app/components/MobileControls.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { Info, X } from 'lucide-react';
+import { useState } from 'react';
+
+export default function MobileControls() {
+  const [showInfo, setShowInfo] = useState(true);
+
+  if (!showInfo) return null;
+
+  return (
+    <div className="sm:hidden fixed bottom-4 left-4 right-4 bg-gray-900/95 backdrop-blur-sm rounded-lg shadow-xl border border-gray-700 p-3">
+      <div className="flex items-start justify-between gap-2">
+        <Info className="w-4 h-4 text-blue-400 flex-shrink-0 mt-0.5" />
+        <div className="flex-1 space-y-1">
+          <p className="text-xs font-medium text-gray-300">Touch Controls</p>
+          <ul className="text-xs text-gray-400 space-y-0.5">
+            <li>• One finger drag: Rotate</li>
+            <li>• Two finger drag: Pan</li>
+            <li>• Pinch: Zoom in/out</li>
+          </ul>
+        </div>
+        <button
+          onClick={() => setShowInfo(false)}
+          className="text-gray-400 hover:text-white transition-colors"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/components/ViewerSettings.tsx
+++ b/app/components/ViewerSettings.tsx
@@ -36,28 +36,28 @@ export default function ViewerSettings({
   ];
 
   return (
-    <div className={`absolute top-4 left-4 ${className}`}>
-      <div className="bg-gray-900/90 backdrop-blur-sm rounded-lg shadow-xl border border-gray-700 p-2 min-w-[240px]">
+    <div className={`absolute top-2 sm:top-4 left-2 sm:left-4 ${className}`}>
+      <div className="bg-gray-900/90 backdrop-blur-sm rounded-lg shadow-xl border border-gray-700 p-1 sm:p-2 min-w-[200px] sm:min-w-[240px]">
         {/* Settings Toggle */}
         <button
           onClick={() => setIsExpanded(!isExpanded)}
-          className="w-full flex items-center gap-2 px-3 py-2 text-gray-300 hover:text-white transition-colors"
+          className="w-full flex items-center gap-1 sm:gap-2 px-2 sm:px-3 py-1 sm:py-2 text-gray-300 hover:text-white transition-colors"
         >
-          <Settings className="w-5 h-5" />
-          <span className="text-sm font-medium">Viewer Settings</span>
-          <ChevronDown className={`w-4 h-4 ml-auto transition-transform ${isExpanded ? 'rotate-180' : ''}`} />
+          <Settings className="w-4 sm:w-5 h-4 sm:h-5" />
+          <span className="text-xs sm:text-sm font-medium">Settings</span>
+          <ChevronDown className={`w-3 sm:w-4 h-3 sm:h-4 ml-auto transition-transform ${isExpanded ? 'rotate-180' : ''}`} />
         </button>
 
         {/* Expanded Settings */}
         {isExpanded && (
-          <div className="mt-2 pt-2 border-t border-gray-700 space-y-4">
+          <div className="mt-1 sm:mt-2 pt-1 sm:pt-2 border-t border-gray-700 space-y-2 sm:space-y-4">
             {/* Quality Setting */}
-            <div className="px-3">
-              <div className="flex items-center gap-2 mb-2">
-                <Gauge className="w-4 h-4 text-gray-400" />
-                <span className="text-sm font-medium text-gray-300">Quality</span>
+            <div className="px-2 sm:px-3">
+              <div className="flex items-center gap-1 sm:gap-2 mb-1 sm:mb-2">
+                <Gauge className="w-3 sm:w-4 h-3 sm:h-4 text-gray-400" />
+                <span className="text-xs sm:text-sm font-medium text-gray-300">Quality</span>
               </div>
-              <div className="space-y-1">
+              <div className="space-y-0.5 sm:space-y-1">
                 {qualityOptions.map((option) => (
                   <button
                     key={option.value}
@@ -65,26 +65,26 @@ export default function ViewerSettings({
                       onQualityChange?.(option.value);
                       setHasChanges(true);
                     }}
-                    className={`w-full text-left px-3 py-2 rounded-md text-sm transition-all ${
+                    className={`w-full text-left px-2 sm:px-3 py-1 sm:py-2 rounded-md text-xs sm:text-sm transition-all ${
                       currentQuality === option.value
                         ? 'bg-blue-600 text-white'
                         : 'bg-gray-800 text-gray-300 hover:bg-gray-700 hover:text-white'
                     }`}
                   >
                     <div className="font-medium">{option.label}</div>
-                    <div className="text-xs opacity-70">{option.description}</div>
+                    <div className="text-xs opacity-70 hidden sm:block">{option.description}</div>
                   </button>
                 ))}
               </div>
             </div>
 
             {/* Render Mode Setting */}
-            <div className="px-3">
-              <div className="flex items-center gap-2 mb-2">
-                <Palette className="w-4 h-4 text-gray-400" />
-                <span className="text-sm font-medium text-gray-300">Render Mode</span>
+            <div className="px-2 sm:px-3">
+              <div className="flex items-center gap-1 sm:gap-2 mb-1 sm:mb-2">
+                <Palette className="w-3 sm:w-4 h-3 sm:h-4 text-gray-400" />
+                <span className="text-xs sm:text-sm font-medium text-gray-300">Render Mode</span>
               </div>
-              <div className="space-y-1">
+              <div className="space-y-0.5 sm:space-y-1">
                 {renderModes.map((mode) => (
                   <button
                     key={mode.value}
@@ -92,14 +92,14 @@ export default function ViewerSettings({
                       onRenderModeChange?.(mode.value);
                       setHasChanges(true);
                     }}
-                    className={`w-full text-left px-3 py-2 rounded-md text-sm transition-all ${
+                    className={`w-full text-left px-2 sm:px-3 py-1 sm:py-2 rounded-md text-xs sm:text-sm transition-all ${
                       currentRenderMode === mode.value
                         ? 'bg-blue-600 text-white'
                         : 'bg-gray-800 text-gray-300 hover:bg-gray-700 hover:text-white'
                     }`}
                   >
                     <div className="font-medium">{mode.label}</div>
-                    <div className="text-xs opacity-70">{mode.description}</div>
+                    <div className="text-xs opacity-70 hidden sm:block">{mode.description}</div>
                   </button>
                 ))}
               </div>
@@ -107,8 +107,8 @@ export default function ViewerSettings({
             
             {/* Restart hint */}
             {hasChanges && (
-              <div className="px-3 pb-2">
-                <div className="bg-yellow-500/20 border border-yellow-500/50 rounded-md p-2 text-xs text-yellow-300">
+              <div className="px-2 sm:px-3 pb-1 sm:pb-2">
+                <div className="bg-yellow-500/20 border border-yellow-500/50 rounded-md p-1 sm:p-2 text-xs text-yellow-300">
                   Settings will apply after refreshing the page
                 </div>
               </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,13 +9,13 @@ const GaussianSplatViewer = dynamic(
 
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-4 bg-gray-900">
+    <main className="flex min-h-screen flex-col items-center justify-center p-2 sm:p-4 bg-gray-900">
       <div className="w-full max-w-6xl">
-        <h1 className="text-4xl font-bold text-white text-center mb-8">
+        <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-white text-center mb-4 sm:mb-6 md:mb-8">
           Gaussian Splats 3D Viewer
         </h1>
         
-        <div className="w-full h-[600px] bg-black rounded-lg overflow-hidden shadow-2xl">
+        <div className="w-full h-[400px] sm:h-[500px] md:h-[600px] lg:h-[700px] bg-black rounded-lg overflow-hidden shadow-2xl">
           <GaussianSplatViewer 
             modelUrl="/models/storeroom.ply"
             className="w-full h-full"


### PR DESCRIPTION
- Made main page layout responsive with adaptive padding and font sizes
- Updated viewer height to scale with screen size (400px to 700px)
- Made CameraControls responsive with smaller touch targets on mobile
- Made ViewerSettings responsive with hidden descriptions on mobile
- Created MobileControls component for touch gesture instructions
- Updated loading and error states with responsive sizing
- Hidden desktop control instructions on mobile devices
- Optimized UI space usage for smaller screens

Breakpoints:
- sm: 640px+ (tablets)
- md: 768px+ (small laptops)
- lg: 1024px+ (desktops)

🤖 Generated with [Claude Code](https://claude.ai/code)